### PR TITLE
Made changes to convert this to a semi-automatic script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # Klipper Github Backup
-Backup Klipper config to github
+Backup your Klipper config to github
 
 ## Instructions
-
-For downloading this script it is necessary to have git installed.
-If you haven't, run `sudo apt-get install git -y` to install git first.
 
 Assuming you already have a Github account 
 
@@ -12,51 +9,17 @@ Assuming you already have a Github account
 2. Create a token for access to the repo (Settings--Developer--Personal Access Tokens)
 3. SSH To the printer and run the commands below. Replace the values with your actual ```USERNAME, EMAIL, TOKEN AND REPOSITORY```
 
-## Setting up Git
+Git is a dependency for this script to run please make sure to install git if you have not already `sudo apt-get install git -y`
 
-``` sudo apt-get install git -y
-cd ~/printer_data/config
-git init
-git config --global user.name "USERNAME"
-git config --global user.email "EMAIL"
-git remote add origin https://USERNAME:TOKEN@REPOSITORY URL
-git add .  (Note the ".", this is important)
-git commit -m "Initial backup" 
-git push -u origin master 
-```
+To get started with this script navigate to your home folder on your device and down the script `wget -q https://raw.githubusercontent.com/housam-s/Klipper-Backup/main/backup.sh`
+Make the script executable `chmod +x backup.sh`
 
-###### Note: This will only need to be done once as we will use a macro later to do this
+Now run the script for the first time `./backup.sh` and you will be prompted to input your Git Username, Email Address, Token and Repo URL.
+**It is very important for the Repository URL that you DO NOT include the https://**
 
-## Setting up Klipper for backup
+When you next run the script via `./backup.sh` or using the macro it will not prompt you for these details again.
 
-1. Open WinSCP and connect to your printer
-
-   Download the backup.sh file [here](https://github.com/housam-s/Klipper-Backup/blob/main/backup.sh/)
-   You may have to check/change your klipper config path in this file on line 8. By default it is /home/pi/klipper_config. Newer klipper installations now use /home/pi/printer_data/config
-   
-2. Copy the “backup.sh” file into the pi folder. `/home/pi`
-3. Copy the “gcode_shell_command.py”: file into the extras folder. `/klipper/klippy/extras`
-
-   Download link is [here](https://github.com/th33xitus/kiauh/blob/150ef0142fae7b1b0ffc6e27149dba0f3ac86ac7/resources/gcode_shell_command.py/).
-
-
-4. Add the following to a macro or printer.cfg file
-
-```
-[gcode_shell_command backup_to_github]
-command: sh /home/pi/backup.sh
-timeout: 30.
-verbose: True
-```
-
-```
-[gcode_macro GITHUB_BACKUP]
-gcode:
-    RUN_SHELL_COMMAND CMD=backup_to_github
-```    
-
-This will create a macro button to run the backup. 
-At this point, it is recommended to reboot the pi.
+To finish the installation it is recommended to reboot the device you have installed the script on.
 
 #### You can choose to automate this backup process by calling the macro or the backup.sh script. This can be setup to run as a cron or even at the start/end of a print. I will leave this up to you. 
 

--- a/backup.cfg
+++ b/backup.cfg
@@ -1,6 +1,6 @@
 [gcode_shell_command backup_to_github]
-command: sh /home/pi/backup.sh
-timeout: 30.
+command: sh replaceme
+timeout: 300.
 verbose: True
 
 [gcode_macro GITHUB_BACKUP]

--- a/backup.sh
+++ b/backup.sh
@@ -1,66 +1,57 @@
 #!/bin/bash
-#
-#####################################################################
-### Please set the paths accordingly. In case you don't have all  ###
-### the listed folders, just keep that line commented out.        ###
-#####################################################################
-### Path to your config folder you want to backup
-#this has been recently updated to /home/pi/printer_data/config 
-#please check your config folder path and update it below
-config_folder=/home/pi/printer_data/config
-#
-### Path to your Klipper folder, by default that is '~/klipper'
-klipper_folder=/home/pi/klipper
-#
-### Path to your Moonraker folder, by default that is '~/moonraker'
-moonraker_folder=/home/pi/moonraker
-#
-### Path to your Mainsail folder, by default that is '~/mainsail'
-#mainsail_folder=/home/pi/mainsail
-#
-### Path to your Fluidd folder, by default that is '~/fluidd'
-fluidd_folder=~/fluidd
-#
-#####################################################################
-#####################################################################
-#
-#
-#####################################################################
-################ !!! DO NOT EDIT BELOW THIS LINE !!! ################
-#####################################################################
-grab_version(){
-  if [ ! -z "$klipper_folder" ]; then
-    echo -n "Getting klipper version="
-    cd "$klipper_folder"
-    klipper_commit=$(git rev-parse --short=7 HEAD)
-    m1="Klipper on commit: $klipper_commit"
-    echo $klipper_commit
-    cd ..
-  fi
-  if [ ! -z "$moonraker_folder" ]; then
-    echo -n "Getting moonraker version="
-    cd "$moonraker_folder"
-    moonraker_commit=$(git rev-parse --short=7 HEAD)
-    m2="Moonraker on commit: $moonraker_commit"
-    echo $moonraker_commit
-    cd ..
-  fi
-  if [ ! -z "$mainsail_folder" ]; then
-    echo -n "Getting mainsail version="
-    mainsail_ver=$(head -n 1 $mainsail_folder/.version)
-    m3="Mainsail version: $mainsail_ver"
-    echo $mainsail_ver
-  fi
-  if [ ! -z "$fluidd_folder" ]; then
-    echo -n "Getting fluidd version="
-    fluidd_ver=$(head -n 1 $fluidd_folder/.version)
-    m4="Fluidd version: $fluidd_ver"
-    echo $fluidd_ver
-  fi
+###########################
+## Klipper Backup Script ##
+#### Created by m00se #####
+###########################
+
+#Download gcode_shell_command.py and place it in~/klipper/klippy/extras/
+addshellcommand(){ 
+  cd ~/klipper/klippy/extras/
+  wget -q https://raw.githubusercontent.com/housam-s/Klipper-Backup/main/gcode_shell_command.py
+  echo gcode_shell_command.py is now present
 }
 
+#Download backup macro and add it to ~/printer_data/config/printer.cfg
+addmacro(){  
+  sed -i '1 i\[include backup.cfg]\n' ~/printer_data/config/printer.cfg
+  echo backup.cfg has been included in printer.cfg
+  cd ~/printer_data/config/
+  wget -q https://raw.githubusercontent.com/housam-s/Klipper-Backup/main/backup.cfg
+  sed -i 's|replaceme|/home/'$USER'/backup.sh |g' ~/printer_data/config/backup.cfg
+  echo backup.cfg is now present
+}
+
+#Setup Git connectivity in ~/printer_data/config
+getgit(){
+  echo What is your Git Username?
+  read vargitusername
+  sleep 1
+  echo What is your Git Email Address?
+  read vargitemail
+  sleep 1
+  echo What is your Git Token
+  read vargittoken
+  sleep 1
+  echo What is your Git Repository URL
+  read vargitrepo
+
+  cd ~/printer_data/config
+  git init
+  sleep 1
+  git config --global user.name "$vargitusername"
+  git config --global user.email "$vargitemail"
+  git remote add origin https://$vargitusername:$vargittoken@$vargitrepo
+  git add .
+  git commit -m "Initial backup"
+  git push -u origin master
+  sleep 1
+  echo Setup Completed
+  exit
+}
+
+#Backup ~/printer_data/config and push it to Github
 push_config(){
-  cd $config_folder
+  cd ~/printer_data/config
   echo Pushing updates
   sleep 1
   git pull -v
@@ -69,10 +60,29 @@ push_config(){
   sleep 1
   current_date=$(date +"%Y-%m-%d %T")
   git commit -m "Backup triggered on $current_date" -m "$m1" -m "$m2" -m "$m3" -m "$m4"
-  git push
+  git push -u origin master
 }
 
-sleep 1
-grab_version
-sleep 1
-push_config
+#Controlling Task
+run(){
+  shellcommandpath=~/klipper/klippy/extras/gcode_shell_command.py
+  if [ ! -f "$shellcommandpath" ]; then
+    echo gcode_shell_command.py is not present
+    addshellcommand
+  fi
+  macropath=~/printer_data/config/backup.cfg
+  if [ ! -f "$macropath" ]; then
+    echo Macro not installed
+    addmacro
+  fi
+  gitpath=~/printer_data/config/.git
+  if [ ! -d "$gitpath" ]; then
+    echo Git not configured
+    getgit
+  fi
+  sleep 1
+  push_config
+  sleep 1
+}
+
+run


### PR DESCRIPTION
Made changes to convert this to a semi-automatic script

+ Setup is run on backup.sh
+ User is prompted to enter git details, pathing is determined by Klipper relative paths or the home directory user
+ Automatically installs gcode_shell_command.py from your repo